### PR TITLE
feat(netlify): add Storybook branch context

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,20 +1,23 @@
-# netlify.toml
-
 [build]
-  command   = "npm run build"
-  publish   = "dist"
+  command = "npm run build"
+  publish = "dist"
 
-# Билд для production-контекста (слияния в main)
+# Production build (merge into main)
 [context.production]
-  command   = "npm run build"
-  publish   = "dist"
+  command = "npm run build"
+  publish = "dist"
 
-# Пропустить сборку для Deploy Previews
+# Skip builds for Deploy Previews
 [context.deploy-preview]
-  command   = "echo \"Skipping deploy preview\" && exit 0"
-  publish   = "dist"
+  command = "echo \"Skipping deploy preview\" && exit 0"
+  publish = "dist"
 
-# Пропустить сборку для любых других веток, если нужно
+# Skip builds for all other branches by default
 [context.branch-deploy]
-  command   = "echo \"Skipping branch deploy\" && exit 0"
-  publish   = "dist"
+  command = "echo \"Skipping branch deploy\" && exit 0"
+  publish = "dist"
+
+# Run Storybook build on the `storybook` branch
+[context."branch=storybook"]
+  command = "npm run build-storybook"
+  publish = "storybook-static"


### PR DESCRIPTION
## Description
This MR adds a Netlify context for the `storybook` branch, so that when that branch is deployed, Netlify will:
- Run `npm run build-storybook`
- Publish the resulting `storybook-static` directory

Builds on `main` and production still use `npm run build` → `dist`, and previews/other branches remain skipped.

## Changes
- **netlify.toml**: added `[context."branch=storybook"]` with appropriate `command` and `publish` settings.

## Testing
1. Push changes to the `storybook` branch.
2. Confirm Netlify runs `npm run build-storybook` and deploys Storybook correctly.
3. Verify production (main) builds and previews behave as before.
