### PR TITLE
ci(github): add workflow to auto-deploy storybook to 'storybook' branch after merging to main

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,38 @@
+name: Deploy Storybook to 'storybook' branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy-storybook:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Deploy to storybook branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B storybook
+          git add -f storybook-static
+          git commit -m "chore(storybook): deploy storybook [auto]" || echo "Nothing to commit"
+
+          git push -f origin storybook

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,20 +1,27 @@
-# netlify.toml
-
+# Общие настройки
 [build]
-  command   = "npm run build"
-  publish   = "dist"
+  command = "npm run build"
+  publish = "dist"
 
-# Билд для production-контекста (слияния в main)
+# === Основной проект: frtvt-marketplace ===
 [context.production]
-  command   = "npm run build"
-  publish   = "dist"
+  command = "npm run build"
+  publish = "dist"
 
-# Пропустить сборку для Deploy Previews
 [context.deploy-preview]
-  command   = "echo \"Skipping deploy preview\" && exit 0"
-  publish   = "dist"
+  command = "mkdir -p dist && echo 'Skipping deploy preview' && exit 0"
+  publish = "dist"
 
-# Пропустить сборку для любых других веток, если нужно
 [context.branch-deploy]
-  command   = "echo \"Skipping branch deploy\" && exit 0"
-  publish   = "dist"
+  command = "mkdir -p dist && echo 'Skipping branch deploy' && exit 0"
+  publish = "dist"
+
+# === Storybook-проект: frtvt-marketplace-storybook ===
+[context."branch=storybook"]
+  command = "npm run build-storybook"
+  publish = "storybook-static"
+
+  [[context."branch=storybook".redirects]]
+    from = "/*"
+    to = "/index.html"
+    status = 200


### PR DESCRIPTION
This MR introduces full automation for Storybook deployment via GitHub Actions and Netlify:

#### ✅ GitHub Action (`deploy-storybook.yml`)
- Triggers on every push to `main`
- Builds Storybook using `npm run build-storybook`
- Commits and force-pushes output (`storybook-static/`) to a dedicated `storybook` branch
- Uses official `github-actions[bot]` identity for commit history

#### ✅ Updated `netlify.toml`
- Configures Netlify to:
  - Build the main app only in `main`
  - Skip deploy previews and other branches by default
  - Build and publish Storybook **only** in the `storybook` branch
  - Adds redirect `/* → /index.html` for Storybook SPA routing

This setup cleanly separates production and Storybook deploys while maintaining automation after each merge to `main`.
